### PR TITLE
Fixed edit delete buttons and doughnut chart on mobile devices

### DIFF
--- a/client/src/components/DoughnutChart.js
+++ b/client/src/components/DoughnutChart.js
@@ -66,8 +66,8 @@ function DoughnutChart(props)
             <div className="chart_container p-5">
                 {showChart ? (<Chart 
                     type="donut"
-                    width={420}
-                    height={420}
+                    width="100%"
+                    height="480"
 
                     series={[foodExpenses, travelExpenses, shoppingExpenses, billsExpenses, othersExpenses]}
 
@@ -79,6 +79,9 @@ function DoughnutChart(props)
                                 colors: "#000000"
                             }
                         },
+                        
+
+                        
 
                     }}
                 >

--- a/client/src/styles/DoughnutChart.css
+++ b/client/src/styles/DoughnutChart.css
@@ -2,4 +2,6 @@
 {
     font-family: 'Lato', sans-serif;
     letter-spacing: 0.5px;
+    width: 100%;
+    max-width: 420px;
 }

--- a/client/src/styles/ExpenseTracker.css
+++ b/client/src/styles/ExpenseTracker.css
@@ -299,4 +299,7 @@
         margin-top: 75px;
         color: black;
     }
+    .editDelete_container{
+        width: 60px;
+    }
 }


### PR DESCRIPTION
Fixes: #120 

The edit and delete buttons will now be visible everytime on <=480px devices.
The doughnut chart was causing overflow issues in smaller devices is also fixed.