### PR TITLE
Changed DoughnutChart.css

### DIFF
--- a/client/src/styles/DoughnutChart.css
+++ b/client/src/styles/DoughnutChart.css
@@ -3,6 +3,6 @@
     font-family: 'Lato', sans-serif;
     letter-spacing: 0.5px;
     width: 100%;
-    max-width: 420px;
+    max-width: 430px;
     box-sizing: border-box;
 }


### PR DESCRIPTION
Increased the max-width of the chart container div slightly to adjust the text within single line. 
Earlier, the width was enough only to accomodate the chart and not the text in a single line. It is resolved now.