### PR TITLE
FIX: Disabled cursor on disabled category

### DIFF
--- a/client/src/components/ExpenseTracker.js
+++ b/client/src/components/ExpenseTracker.js
@@ -408,7 +408,7 @@ function ExpenseTracker()
                                 value={formData.category}
                                 onChange={handleChange}
                                 required
-                                style={{ cursor: formData.transactionType === "Income" ? "auto" : "pointer" }}
+                                style={{ cursor: formData.transactionType === "Income" ? "not-allowed" : "pointer" }}
                                 disabled={formData.transactionType === "Income"}
                             >
                                 <option value="NULL">Choose a category</option>


### PR DESCRIPTION
## Pull Request

**Related Issues:**
[List any related issues or reference them using the syntax `#issue_number`.]

Fixes #(issue number)
#141 

**Description:**
Add a not-allowed cursor type instead of auto when transaction type "income" is selected

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**

https://github.com/ani1609/Spendwise/assets/65119631/6a1f6bd9-0630-483c-a081-cc8f3b132dc7

