### PR TITLE
Fixed labels overlapping

### DIFF
--- a/client/src/components/DoughnutChart.js
+++ b/client/src/components/DoughnutChart.js
@@ -63,7 +63,7 @@ function DoughnutChart(props)
 
     return(
         <React.Fragment>
-            <div className="chart_container p-5">
+            <div className="chart_container pb-5">
                 {showChart ? (<Chart 
                     type="donut"
                     width="100%"


### PR DESCRIPTION
## Pull Request

**Related Issues:**
#148 Labels gets new line when screen size below 408px.

Fixes #148 

**Description:**
When the screen size <=408px, the labels below chart forms new line even though spaces is available. I changed padding from applying to all sides to only bottom. 

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**
![Screenshot 2023-12-10 190503](https://github.com/ani1609/Spendwise/assets/149917528/148b1434-6fc8-4ff8-91c1-1e533df87277)

