### PR TITLE
changed transaction border color to #B6CEFC80

### DIFF
--- a/client/src/components/Transactions.js
+++ b/client/src/components/Transactions.js
@@ -206,7 +206,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                 {transactionFilter.map((transaction, index) => (
                   transaction.transactionType === "Income"
                     ? (
-                    <li key={index} className="income flex justify-between items-center border-2 rounded p-2">
+                    <li key={index} className="income flex justify-between items-center border-2 rounded p-2 dark:border-[#B6CEFC80]">
                         <div className="icon_container">
                         <Plus className="icons" />
                         </div>


### PR DESCRIPTION
## Pull Request

**Related Issues:**
[#276](https://github.com/ani1609/Spendwise/issues/276#event-11348755724)

Fixes #(issue number)

**Description:**
changed transaction border color to #B6CEFC80

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**
before
<img width="1440" alt="Screenshot 2023-12-28 at 16 14 09" src="https://github.com/ani1609/Spendwise/assets/13862160/001ac970-c3dc-4a50-ac7d-8a5b0fc03e87">

after
<img width="1440" alt="Screenshot 2023-12-28 at 16 12 39" src="https://github.com/ani1609/Spendwise/assets/13862160/1500ae58-bcd1-4274-817a-1de60510c4fc">

