### PR TITLE
change transaction filter border color

### DIFF
--- a/client/src/components/Transactions.js
+++ b/client/src/components/Transactions.js
@@ -157,7 +157,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                 <div className="flex justify-between mt-3">
                     <div className="form-group col-md-4">
                     <div className="custom-dropdown" onBlur={closeDropdown} tabIndex={0}>
-                        <div className="selected-value w-[126px] px-4 rounded cursor-pointer border-[1px] border-black dark:border-[#e1e1e1]" onClick={toggleDropdown}>
+                        <div className="selected-value w-[126px] px-4 rounded cursor-pointer border-[1px] border-black dark:border-[#B6CEFC80]" onClick={toggleDropdown}>
                         {transactionType || "Type"}<i className="arrow down"></i>
                         </div>
                         {isDropdownOpen && (
@@ -172,7 +172,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                     <div>
                     <div className="form-group col-md-4">
                     <div className="custom-dropdown" onBlur={closeCategoryDropdown} tabIndex={0}>
-                        <div className="selected-value w-[126px] px-4 rounded cursor-pointer border-[1px] border-black dark:border-[#e1e1e1]" onClick={toggleCategoryDropdown}>
+                        <div className="selected-value w-[126px] px-4 rounded cursor-pointer border-[1px] border-black dark:border-[#B6CEFC80]" onClick={toggleCategoryDropdown}>
                         {categoryFilter || "Category"}<i className="arrow down"></i>
                         </div>
                         {isCategoryDropdownOpen && (
@@ -195,7 +195,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                     onChange={(e) => changeDateFilter(e)}
                     placeholder="Date"
                     required
-                    className="cursor-pointer max_with border border-slate-500 rounded-md bg-transparent h-7 px-1 dark:border-[#e1e1e1]"
+                    className="cursor-pointer max_with border border-slate-500 rounded-md bg-transparent h-7 px-1 dark:border-[#B6CEFC80]"
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Pull Request

**Related Issues:**
[#277](https://github.com/ani1609/Spendwise/issues/277#event-11348754804)

Fixes #(issue number)
#277

**Description:**
change all transaction filter borders color to #B6CEFC80

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**

before
<img width="1440" alt="Screenshot 2023-12-28 at 16 27 01" src="https://github.com/ani1609/Spendwise/assets/13862160/cf7351f4-e652-48b3-a89f-4a2e6d76f39f">

after
<img width="1440" alt="Screenshot 2023-12-28 at 16 29 43" src="https://github.com/ani1609/Spendwise/assets/13862160/9642fb31-7027-4e7c-8dfb-3c86e45f12e6">

