### PR TITLE
fix the issue where charts labels was not visible in dark mode

### DIFF
--- a/client/src/components/DoughnutChart.js
+++ b/client/src/components/DoughnutChart.js
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import Chart from "react-apexcharts";
+import { ThemeContext } from "../context/ThemeContext";
 import "../styles/DoughnutChart.css";
 import "../index.css";
 
@@ -11,6 +12,7 @@ function DoughnutChart (props) {
   const [shoppingExpenses, setShoppingExpenses] = useState(0);
   const [billsExpenses, setBillsExpenses] = useState(0);
   const [othersExpenses, setOthersExpenses] = useState(0);
+  const { theme } = useContext(ThemeContext);
 
   useEffect(() => {
     if (transactions) {
@@ -68,7 +70,7 @@ function DoughnutChart (props) {
                       legend: {
                         position: "bottom",
                         labels: {
-                          colors: "#000000"
+                          colors: theme === "dark" ? "#B6CEFC80" : "#000"
                         }
                       }
 


### PR DESCRIPTION
## Pull Request

Fixes #279 

**Description:**
The bug was charts label was not visible in dark mode. Just add the ThemeContext with useContext and check for the theme and change the label color accordingly 

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation (if applicable).

**Screenshots:**
![ss](https://github.com/ani1609/Spendwise/assets/80758388/3d9412c5-960e-4cc6-a51f-f78f261b6048)

