### PR TITLE
border colors of transactions for dark mode has been change to #B6CEF…

### DIFF
--- a/client/src/components/Transactions.js
+++ b/client/src/components/Transactions.js
@@ -206,7 +206,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                 {transactionFilter.map((transaction, index) => (
                   transaction.transactionType === "Income"
                     ? (
-                    <li key={index} className="income flex justify-between items-center border rounded p-2 transition-all duration-500">
+                    <li key={index} className="income flex justify-between items-center border border-[#6e9df7] dark:border-[#B6CEFC80] rounded p-2 transition-all duration-500">
                         <div className="icon_container transition-all duration-500 dark:bg-[#335467]">
                         <Plus className="icons transition-all duration-500 dark:fill-[rgba(19,43,57,1)]" />
                         </div>
@@ -222,7 +222,7 @@ function Transactions ({ transactions, setTransactions, user, setEditEnabled, se
                     </li>
                       )
                     : (
-                    <li key={index} className="outcome flex justify-between items-center border rounded p-2 transition-all duration-500">
+                    <li key={index} className="outcome flex justify-between items-center border border-[#6e9df7] dark:border-[#B6CEFC80] rounded p-2 transition-all duration-500">
                         <div className="icon_container transition-all duration-500 dark:bg-[#335467]">
                         {transaction.category === "Food" ? <Food className="icons transition-all duration-500 dark:fill-[rgba(19,43,57,1)]" /> : null}
                         {transaction.category === "Travel" ? <Travel className="icons transition-all duration-500 dark:fill-[rgba(19,43,57,1)]" /> : null}

--- a/client/src/styles/ExpenseTracker.css
+++ b/client/src/styles/ExpenseTracker.css
@@ -103,7 +103,7 @@
   box-sizing: border-box;
   height: 70px;
   position: relative;
-  border-color: var(--border);
+  /* border-color: var(--border); */
 }
 
 .income::after {


### PR DESCRIPTION
…C80. issue solved

## Pull Request

**Related Issues:**
https://github.com/ani1609/Spendwise/issues/295

Fixes #(issue number)
#295

**Description:**
Step 1 -
ExpenseTracker.css file:
commented out  106 line.

Step 2 -
Transactions.js file:
Added "border-[#6e9df7] dark:border-[#B6CEFC80]" to className of li html tag at ine 209 and 225

**Checklist:**
- [ ✔ ] I have tested my changes.
- [ ✔ ] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**
![dark mode border](https://github.com/ani1609/Spendwise/assets/81553366/a42432c1-c1df-44f4-b6f5-20687165be42)

